### PR TITLE
Corutines news fetch

### DIFF
--- a/KudaGoAPIClient/src/main/kotlin/MainAPI.kt
+++ b/KudaGoAPIClient/src/main/kotlin/MainAPI.kt
@@ -24,7 +24,7 @@ fun main() = runBlocking {
     newsService.saveNews(filePath, mostRatedNews)
 
     try {
-        val newsList: List<News> = newsRepository.getAllNews(count = 10)
+        val newsList: List<News> = newsRepository.getNews(count = 10)
 
         println("Retrieved ${newsList.size} news articles:")
         newsList.forEach { news ->

--- a/KudaGoAPIClient/src/main/kotlin/repository/NewsKudaGoRepository.kt
+++ b/KudaGoAPIClient/src/main/kotlin/repository/NewsKudaGoRepository.kt
@@ -13,8 +13,7 @@ private val logger = KotlinLogging.logger {}
 class NewsKudaGoRepository(
     private val client: HttpClient,
 ) {
-
-    suspend fun getAllNews(count: Int = 100): List<News> {
+    suspend fun getNews(page: Int = 1, count: Int = 100): List<News> {
         val location = "nsk"
         val fields = "id,title,publication_date,place,description,site_url,favorites_count,comments_count"
 
@@ -28,6 +27,7 @@ class NewsKudaGoRepository(
                 parameter("page_size", count)
                 parameter("order_by", "-publication_date")
                 parameter("location", location)
+                parameter("page", page)
             }.bodyAsText()
         } catch (e: Exception) {
             logger.error(e) { "Error while fetching news" }
@@ -40,7 +40,7 @@ class NewsKudaGoRepository(
             throw e
         }
 
-        logger.info { "Successfully retrieved ${newsResponse.results.size} news articles" }
+        logger.info { "Successfully retrieved ${newsResponse.results.size} news articles on page: $page" }
 
         return newsResponse.results
     }

--- a/KudaGoAPIClient/src/main/kotlin/service/NewsService.kt
+++ b/KudaGoAPIClient/src/main/kotlin/service/NewsService.kt
@@ -14,7 +14,7 @@ class NewsService(private val newsRepository: NewsKudaGoRepository) {
     suspend fun getMostRatedNews(count: Int, period: ClosedRange<LocalDate>): List<News> {
         logger.info { "Fetching top $count most rated news for the period: $period" }
 
-        val allNews = newsRepository.getAllNews(count)
+        val allNews = newsRepository.getNews(1, count)
 
         val filteredNews = allNews
             .filter { it.publicationDate in period }

--- a/KudaGoAPIClient/src/main/kotlin/service/NewsServiceCoroutine.kt
+++ b/KudaGoAPIClient/src/main/kotlin/service/NewsServiceCoroutine.kt
@@ -1,0 +1,96 @@
+package service
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.ktor.client.*
+import io.ktor.client.engine.cio.*
+import kotlinx.coroutines.*
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.actor
+import model.News
+import repository.NewsKudaGoRepository
+import java.io.File
+import java.io.PrintWriter
+import kotlin.system.measureTimeMillis
+
+private val logger = KotlinLogging.logger {}
+
+@OptIn(ObsoleteCoroutinesApi::class)
+private fun CoroutineScope.processorActor(file: File, channel: Channel<List<News>>) = actor<List<News>>(Dispatchers.IO) {
+    PrintWriter(file).use { writer ->
+        logger.info{"Actor: Started writing to file"}
+        writer.println("id,title,place,description,siteUrl,favoritesCount,commentsCount,publicationDate,rating")
+        for (newsList in channel) {
+            logger.info{"Actor: Received a batch of news to write"}
+            newsList.forEach { item ->
+                val formattedPlace = item.place ?: "Not stated"
+                writer.println(
+                    "${item.id}," +
+                            "\"${item.title}\"," +
+                            "\"$formattedPlace\"," +
+                            "\"${item.description}\"," +
+                            "${item.siteUrl}," +
+                            "${item.favoritesCount}," +
+                            "${item.commentsCount}," +
+                            "${item.publicationDate}," +
+                            "${item.rating}"
+                )
+            }
+            }
+            writer.flush()
+        }
+    logger.info{"Actor: Finished writing to file"}
+    }
+
+class NewsServiceCoroutine(
+    private val workerCount: Int,
+    private val threadCount: Int,
+    private val repository: NewsKudaGoRepository
+) {
+    private val channel = Channel<List<News>>(Channel.UNLIMITED)
+
+    @OptIn(DelicateCoroutinesApi::class)
+    fun startProcessing(pages: Int) = runBlocking {
+        val dispatcher = newFixedThreadPoolContext(threadCount, "workerPool")
+
+        val file = File("news_output.csv")
+        val processor = processorActor(file, channel)
+
+        logger.info{"Starting workers"}
+
+        val workers = List(workerCount) { workerId ->
+            launch(dispatcher) {
+                for (page in (workerId + 1)..pages step workerCount) {
+                    logger.info{"Worker $workerId: Fetching news for page $page"}
+                    val news = repository.getNews(page)
+                    logger.info{"Worker $workerId: Sending news for page $page to channel"}
+                    channel.send(news)
+                }
+            }
+        }
+
+        workers.forEach { it.join() }
+        logger.info{"All workers completed"}
+        channel.close()
+        logger.info{"Channel closed"}
+
+        processor.invokeOnClose { logger.info{"Processor has finished writing"}}
+    }
+}
+
+
+fun main() = runBlocking {
+    val client = HttpClient(CIO)
+    val repository = NewsKudaGoRepository(client)
+    val workerCount = 4
+    val threadCount = 2
+
+    val newsService = NewsServiceCoroutine(workerCount, threadCount, repository)
+
+    val time = measureTimeMillis {
+        newsService.startProcessing(pages = 10)
+    }
+
+    logger.info{"Execution time: $time ms"}
+
+    client.close()
+}

--- a/KudaGoAPIClient/src/test/kotlin/repository/NewsKudaGoRepositoryTest.kt
+++ b/KudaGoAPIClient/src/test/kotlin/repository/NewsKudaGoRepositoryTest.kt
@@ -65,7 +65,7 @@ class NewsKudaGoRepositoryTest {
     @Test
     fun `test getAllNews success`() = runTest {
         // Act
-        val result = newsRepository.getAllNews(5)
+        val result = newsRepository.getNews(1,5)
 
         // Assert
         assertEquals(2, result.size)
@@ -81,7 +81,7 @@ class NewsKudaGoRepositoryTest {
         }))
 
         assertFailsWith<Exception> {
-            badRepository.getAllNews(5)
+            badRepository.getNews(1,5)
         }
     }
 
@@ -98,7 +98,7 @@ class NewsKudaGoRepositoryTest {
         val invalidRepo = NewsKudaGoRepository(invalidJsonClient)
 
         assertFailsWith<Exception> {
-            invalidRepo.getAllNews(5)
+            invalidRepo.getNews(1,5)
         }
     }
 }

--- a/KudaGoAPIClient/src/test/kotlin/service/NewsServiceTest.kt
+++ b/KudaGoAPIClient/src/test/kotlin/service/NewsServiceTest.kt
@@ -29,12 +29,12 @@ class NewsServiceTest {
             News(1, "Title1", null, "Description1", "https://site1.com", 10, 5, LocalDate.now()),
             News(2, "Title2", null, "Description2", "https://site2.com", 20, 10, LocalDate.now())
         )
-        coEvery { newsRepository.getAllNews(100) } returns mockNews
+        coEvery { newsRepository.getNews(1,100) } returns mockNews
 
         val result = newsService.getMostRatedNews(2, period)
 
         assertEquals(mockNews, result)
-        coVerify { newsRepository.getAllNews(100) }
+        coVerify { newsRepository.getNews(1,100) }
     }
 
 


### PR DESCRIPTION
| Количество потоков | Время инициализации (ms) |
|--------------------|--------------------------|
| 1                  | 21400                        |
| 2                  | 14503                        |
| 4                  | 8602                          |
| 8                  | 12489                        |
| 10                 | 14309                       |
| 16                 | 20539                       |

Замеры производились на 11th Gen Intel® Core™ i5-11400H
Приведены средние результаты для 10 запросов на каждом количестве потоков.
Время выполнения снижается до 4 потоков, далее затраты на их менеджемент становятся больше чем выгода от их использования. Ситуация аналогичная.